### PR TITLE
fix: Use platform-specific dynamic library names

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,23 +43,30 @@ MacOS (arm64/x64):
 brew install sdl2 sdl2_image sdl2_ttf
 ```
 
-Windows (x64): Grab one of the prebuilt libraries from
-https://buildbot.libsdl.org/sdl-builds/sdl-visualstudio-x86/ and put
-`lib/SDL2.dll` into the root of your project.
+Make sure the libraries is in your system's library search paths, if not
+already:
+
+```shell
+sudo ln -s /opt/homebrew/lib/libSDL2.dylib /usr/local/lib/
+sudo ln -s /opt/homebrew/lib/libSDL2_image.dylib /usr/local/lib/
+sudo ln -s /opt/homebrew/lib/libSDL2_ttf.dylib /usr/local/lib/
+```
+
+Windows (x64):
+
+Grab prebuilt libraries from all of:
+
+- https://buildbot.libsdl.org/sdl-builds/sdl-visualstudio-amd64/
+- https://www.libsdl.org/projects/SDL_image/
+- https://github.com/libsdl-org/SDL_ttf/releases/tag/release-2.0.18
+
+Take `SDL2.dll`, `SDL2_image.dll` and `SDL2_ttf.dll` from each respectively and
+put them into `C:\Windows\System32\`.
 
 Linux (x64):
 
 ```shell
-sudo apt install sdl2 sdl2_image sdl2_ttf
-```
-
-Make sure the libraries is in your system's library search paths, if not
-already:
-
-```bash
-sudo ln -s /opt/homebrew/lib/libSDL2.dylib /usr/local/lib/
-sudo ln -s /opt/homebrew/lib/libSDL2_image.dylib /usr/local/lib/
-sudo ln -s /opt/homebrew/lib/libSDL2_ttf.dylib /usr/local/lib/
+sudo apt install libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev
 ```
 
 ### security

--- a/mod.ts
+++ b/mod.ts
@@ -7,7 +7,24 @@ import {
   u8,
 } from "https://deno.land/x/byte_type@0.1.7/ffi.ts";
 
-const sdl2 = Deno.dlopen(`libSDL2.dylib`, {
+let sdl2Lib;
+let sdl2ImageLib;
+let sdl2TtfLib;
+if (Deno.build.os == "darwin") {
+  sdl2Lib = "libSDL2.dylib";
+  sdl2ImageLib = "libSDL2_image.dylib";
+  sdl2TtfLib = "libSDL2_ttf.dylib";
+} else if (Deno.build.os == "windows") {
+  sdl2Lib = "SDL2.dll";
+  sdl2ImageLib = "SDL2_image.dll";
+  sdl2TtfLib = "SDL2_ttf.dll";
+} else {
+  sdl2Lib = "libSDL2-2.0.so";
+  sdl2ImageLib = "libSDL2_image-2.0.so";
+  sdl2TtfLib = "libSDL2_ttf-2.0.so";
+}
+
+const sdl2 = Deno.dlopen(sdl2Lib, {
   "SDL_Init": {
     "parameters": ["u32"],
     "result": "i32",
@@ -219,7 +236,7 @@ const sdl2 = Deno.dlopen(`libSDL2.dylib`, {
   },
 });
 
-const sdl2Image = Deno.dlopen("libSDL2_image.dylib", {
+const sdl2Image = Deno.dlopen(sdl2ImageLib, {
   "IMG_Init": {
     "parameters": ["u32"],
     "result": "u32",
@@ -230,7 +247,7 @@ const sdl2Image = Deno.dlopen("libSDL2_image.dylib", {
   },
 });
 
-const sdl2Font = Deno.dlopen("libSDL2_ttf.dylib", {
+const sdl2Font = Deno.dlopen(sdl2TtfLib, {
   "TTF_Init": {
     "parameters": [],
     "result": "u32",


### PR DESCRIPTION
Also improve installation instructions.