### PR TITLE
fix: Uncaught TypeError: Invalid FFI pointer type, expected null, integer or BigInt

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -61,7 +61,7 @@ const sdl2 = Deno.dlopen(getLibraryPath("SDL2"), {
   },
   "SDL_CreateWindow": {
     "parameters": [
-      "pointer",
+      "buffer",
       "i32",
       "i32",
       "i32",


### PR DESCRIPTION
Fixed error when trying to build window

**Fixed**
[https://github.com/littledivy/deno_sdl2/issues/55](https://github.com/littledivy/deno_sdl2/issues/55)