### PR TITLE
Fix modern WGSL syntax

### DIFF
--- a/webgpu-examples/boids/boids.ts
+++ b/webgpu-examples/boids/boids.ts
@@ -164,7 +164,7 @@ class Boids {
       },
       fragment: {
         module: drawShader,
-        entryPoint: "main",
+        entryPoint: "frag_main",
         targets: [
           {
             format: "rgba8unorm-srgb",

--- a/webgpu-examples/boids/compute.wgsl
+++ b/webgpu-examples/boids/compute.wgsl
@@ -1,31 +1,29 @@
 struct Particle {
-  pos : vec2<f32>;
-  vel : vec2<f32>;
+  pos : vec2<f32>,
+  vel : vec2<f32>,
 };
 
-[[block]]
 struct SimParams {
-  deltaT : f32;
-  rule1Distance : f32;
-  rule2Distance : f32;
-  rule3Distance : f32;
-  rule1Scale : f32;
-  rule2Scale : f32;
-  rule3Scale : f32;
+  deltaT : f32,
+  rule1Distance : f32,
+  rule2Distance : f32,
+  rule3Distance : f32,
+  rule1Scale : f32,
+  rule2Scale : f32,
+  rule3Scale : f32,
 };
 
-[[block]]
 struct Particles {
-  particles : [[stride(16)]] array<Particle>;
+  particles : array<Particle>,
 };
 
-[[group(0), binding(0)]] var<uniform> params : SimParams;
-[[group(0), binding(1)]] var<storage, read> particlesSrc : Particles;
-[[group(0), binding(2)]] var<storage, read_write> particlesDst : Particles;
+@group(0) @binding(0) var<uniform> params : SimParams;
+@group(0) @binding(1) var<storage, read> particlesSrc : Particles;
+@group(0) @binding(2) var<storage, read_write> particlesDst : Particles;
 
 // https://github.com/austinEng/Project6-Vulkan-Flocking/blob/master/data/shaders/computeparticles/particle.comp
-[[stage(compute), workgroup_size(64)]]
-fn main([[builtin(global_invocation_id)]] global_invocation_id: vec3<u32>) {
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
   let total = arrayLength(&particlesSrc.particles);
   let index = global_invocation_id.x;
   if (index >= total) {

--- a/webgpu-examples/boids/shader.wgsl
+++ b/webgpu-examples/boids/shader.wgsl
@@ -1,9 +1,9 @@
-[[stage(vertex)]]
+@vertex
 fn main(
-    [[location(0)]] particle_pos: vec2<f32>,
-    [[location(1)]] particle_vel: vec2<f32>,
-    [[location(2)]] position: vec2<f32>,
-) -> [[builtin(position)]] vec4<f32> {
+    @location(0) particle_pos: vec2<f32>,
+    @location(1) particle_vel: vec2<f32>,
+    @location(2) position: vec2<f32>,
+) -> @builtin(position) vec4<f32> {
     let angle = -atan2(particle_vel.x, particle_vel.y);
     let pos = vec2<f32>(
         position.x * cos(angle) - position.y * sin(angle),
@@ -12,7 +12,7 @@ fn main(
     return vec4<f32>(pos + particle_pos, 0.0, 1.0);
 }
 
-[[stage(fragment)]]
-fn main() -> [[location(0)]] vec4<f32> {
+@fragment
+fn frag_main() -> @location(0) vec4<f32> {
     return vec4<f32>(1.0, 1.0, 1.0, 1.0);
 }


### PR DESCRIPTION
The webgpu examples have ancient WGSL annotation syntax. This patch cleans that up, and also renames the fragment shader so the name doesn't collide.

Note that it's presenting a black screen, I didn't dig into why we're not seeing correct rendering. But the motivation for this is to capture performance traces in Xcode, so that's good enough.